### PR TITLE
[MRG] Pass the dtype consistency & accuracy tests for ridge

### DIFF
--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -171,7 +171,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
         if sp.issparse(X):
             X_offset, X_var = mean_variance_axis(X, axis=0)
             if not return_mean:
-                X_offset = np.zeros(X.shape[1])
+                X_offset = np.zeros(X.shape[1], dtype=X.dtype)
 
             if normalize:
 
@@ -186,7 +186,7 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X_scale[X_scale == 0] = 1
                 inplace_column_scale(X, 1. / X_scale)
             else:
-                X_scale = np.ones(X.shape[1])
+                X_scale = np.ones(X.shape[1], dtype=X.dtype)
 
         else:
             X_offset = np.average(X, axis=0, weights=sample_weight)
@@ -195,12 +195,12 @@ def _preprocess_data(X, y, fit_intercept, normalize=False, copy=True,
                 X, X_scale = f_normalize(X, axis=0, copy=False,
                                          return_norm=True)
             else:
-                X_scale = np.ones(X.shape[1])
+                X_scale = np.ones(X.shape[1], dtype=X.dtype)
         y_offset = np.average(y, axis=0, weights=sample_weight)
         y = y - y_offset
     else:
-        X_offset = np.zeros(X.shape[1])
-        X_scale = np.ones(X.shape[1])
+        X_offset = np.zeros(X.shape[1], dtype=X.dtype)
+        X_scale = np.ones(X.shape[1], dtype=X.dtype)
         y_offset = 0. if y.ndim == 1 else np.zeros(y.shape[1], dtype=X.dtype)
 
     return X, y, X_offset, y_offset, X_scale

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -469,7 +469,13 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
         self.random_state = random_state
 
     def fit(self, X, y, sample_weight=None):
-        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=np.float64,
+
+        if self.solver in ['svd']:
+            _dtype = [np.float64, np.float32]
+        else:
+            _dtype = np.float64
+
+        X, y = check_X_y(X, y, ['csr', 'csc', 'coo'], dtype=_dtype,
                          multi_output=True, y_numeric=True)
 
         if ((sample_weight is not None) and

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -80,7 +80,7 @@ def _solve_sparse_cg(X, y, alpha, max_iter=None, tol=1e-3, verbose=0):
 
 def _solve_lsqr(X, y, alpha, max_iter=None, tol=1e-3):
     n_samples, n_features = X.shape
-    coefs = np.empty((y.shape[1], n_features))
+    coefs = np.empty((y.shape[1], n_features), dtype=X.dtype)
     n_iter = np.empty(y.shape[1], dtype=np.int32)
 
     # According to the lsqr documentation, alpha = damp^2.

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -470,7 +470,7 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
 
     def fit(self, X, y, sample_weight=None):
 
-        if self.solver in ['svd']:
+        if self.solver in ['svd', 'sparse_cg']:
             _dtype = [np.float64, np.float32]
         else:
             _dtype = np.float64

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -470,7 +470,7 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
 
     def fit(self, X, y, sample_weight=None):
 
-        if self.solver in ['svd', 'sparse_cg']:
+        if self.solver in ['svd', 'sparse_cg', 'cholesky']:
             _dtype = [np.float64, np.float32]
         else:
             _dtype = np.float64

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -186,7 +186,7 @@ def _solve_svd(X, y, alpha):
     idx = s > 1e-15  # same default value as scipy.linalg.pinv
     s_nnz = s[idx][:, np.newaxis]
     UTy = np.dot(U.T, y)
-    d = np.zeros((s.size, alpha.size))
+    d = np.zeros((s.size, alpha.size), dtype=X.dtype)
     d[idx] = s_nnz / (s_nnz ** 2 + alpha)
     d_UT_y = d * UTy
     return np.dot(Vt.T, d_UT_y).T
@@ -327,7 +327,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
         y = check_array(y, dtype=np.float64, ensure_2d=False, order='F')
     else:
         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'],
-                        dtype=np.float64)
+                        dtype='numeric')
         y = check_array(y, dtype='numeric', ensure_2d=False)
     check_consistent_length(X, y)
 
@@ -371,7 +371,7 @@ def ridge_regression(X, y, alpha, sample_weight=None, solver='auto',
             X, y = _rescale_data(X, y, sample_weight)
 
     # There should be either 1 or n_targets penalties
-    alpha = np.asarray(alpha).ravel()
+    alpha = np.asarray(alpha, dtype=X.dtype).ravel()
     if alpha.size not in [1, n_targets]:
         raise ValueError("Number of targets and number of penalties "
                          "do not correspond: %d != %d"

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -111,7 +111,7 @@ def _solve_cholesky(X, y, alpha):
         return linalg.solve(A, Xy, sym_pos=True,
                             overwrite_a=True).T
     else:
-        coefs = np.empty([n_targets, n_features])
+        coefs = np.empty([n_targets, n_features], dtype=X.dtype)
         for coef, target, current_alpha in zip(coefs, Xy.T, alpha):
             A.flat[::n_features + 1] += current_alpha
             coef[:] = linalg.solve(A, target, sym_pos=True,

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -470,7 +470,7 @@ class _BaseRidge(six.with_metaclass(ABCMeta, LinearModel)):
 
     def fit(self, X, y, sample_weight=None):
 
-        if self.solver in ['svd', 'sparse_cg', 'cholesky']:
+        if self.solver in ['svd', 'sparse_cg', 'cholesky', 'lsqr']:
             _dtype = [np.float64, np.float32]
         else:
             _dtype = np.float64

--- a/sklearn/linear_model/ridge.py
+++ b/sklearn/linear_model/ridge.py
@@ -36,7 +36,7 @@ from ..metrics.scorer import check_scoring
 def _solve_sparse_cg(X, y, alpha, max_iter=None, tol=1e-3, verbose=0):
     n_samples, n_features = X.shape
     X1 = sp_linalg.aslinearoperator(X)
-    coefs = np.empty((y.shape[1], n_features))
+    coefs = np.empty((y.shape[1], n_features), dtype=X.dtype)
 
     if n_features > n_samples:
         def create_mv(curr_alpha):

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -801,7 +801,7 @@ def test_dtype_match():
     y_32 = y_64.astype(np.float32)
 
     # solvers = ("svd", "sparse_cg", "cholesky", "lsqr", "sag")
-    solvers = ["svd"]
+    solvers = ["svd", "sparse_cg", "cholesky", "lsqr"]
     for solver in solvers:
 
         # Check type consistency 32bits

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -815,4 +815,4 @@ def test_dtype_match():
         assert_equal(ridge_64.coef_.dtype, X_64.dtype)
 
         # Check accuracy consistency
-        assert_almost_equal(ridge_32.coefs_, ridge_64.coefs_.astype(np.float32))
+        assert_almost_equal(ridge_32.coef_, ridge_64.coef_.astype(np.float32))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
It is #8769 on the official depot.

#### What does this implement/fix? Explain your changes.
Allows to pass the 32-bit dtype consistency & accuracy tests for ridge linear model.

Tested solvers are:
- "svd"
- "sparse_cg"
- "cholesky"
- "lsqr"

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
