### PR TITLE
wip

### DIFF
--- a/sklearn/neighbors/classification.py
+++ b/sklearn/neighbors/classification.py
@@ -21,6 +21,8 @@ from .base import \
 from ..base import ClassifierMixin
 from ..utils import check_array
 
+import pdb
+
 
 class KNeighborsClassifier(NeighborsBase, KNeighborsMixin,
                            SupervisedIntegerMixin, ClassifierMixin):
@@ -391,7 +393,8 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
                                         for ind in neigh_ind[inliers]],
                                        dtype=object)
                 y_pred_k = np.zeros(n_samples, dtype=np.int)
-                mode = self._mode(pred_labels, weights, inliers)
+                mode = self._mode(pred_labels, weights, inliers,
+                                  is_comming_from_sparse_call=True)
                 y_pred_k[inliers] = mode
 
                 if outliers and self.outlier_label != 0:
@@ -419,11 +422,14 @@ class RadiusNeighborsClassifier(NeighborsBase, RadiusNeighborsMixin,
 
         return y_pred
 
-    def _mode(self, pred_labels, weights, inliers):
+    def _mode(self, pred_labels, weights, inliers,
+              is_comming_from_sparse_call=None):
         if weights is None:
             mode = np.array([stats.mode(pl)[0]
                              for pl in pred_labels], dtype=np.int)
         else:
+            if is_comming_from_sparse_call:
+                pdb.set_trace()
             mode = np.array([weighted_mode(pl, w)[0]
                              for (pl, w)
                              in zip(pred_labels, weights[inliers])],


### PR DESCRIPTION
This is a PR regarding [this](https://github.com/scikit-learn/scikit-learn/pull/9059/#discussion_r136551392) concern by @glemaitre. 

The main concern is that in order to do a check into a sparse matrix, this needs to be materialized and @glemaitre is wandering if it could be computed directly from the sparse matrix. The underlying computation is [this one: ](https://github.com/massich/scikit-learn/blob/c54274b5455025eeb0817320981334395fc8801a/sklearn/neighbors/classification.py#L424)

```py
mode = np.array([stats.mode(pl)[0] for pl in pred_labels], dtype=np.int)
```
which could  be changed (for the sparse case) by something this:
```py
def get_sparse_matrix_mode (x_sparse):
      mode, occ = stats.mode(x_sparse.data)
      n_of_zero_values = np.product(x_sparse.shape) - x_spase.nnz
      return mode if occ > n_of_zero_values else 0

mode = np.array([get_sparse_matrix_mode(pl) for pl in pred_labels])
```
The problem comes when the instances of 0 need to be waited. Which is the case [here](https://github.com/massich/scikit-learn/blob/c54274b5455025eeb0817320981334395fc8801a/sklearn/neighbors/classification.py#L429). And any feedback is wellcome. 

Some notes, that I don't know how to include into the discussion but that are important when taking a decission. (They are listed with no particular order).
1 - The case of sparase matrix and weights is never tested. [See this breakpoint](https://github.com/massich/scikit-learn/pull/5/files#diff-364ed6a16c035d2ac7a77e55f1ab7e3bR429) and travis still all green. 

2 - Two different signatures of `self._mode`: `KNeighborsClassifier::_mode (self,neigh,weights)` and ` RadiusNeighborsClassifier::_mode (self,pred_labels,weights,inliers)`. More over neither of them use `self` inside. So shouldn't we unify the signature and use it as a free function. Or in case of really being a class method shouldn't they have the same signature and be added to a parent class? 

3 - In order to unify the call and simply the code weights could always be provided (at expenses of some computing time) and we could even add sparse support to `sklearn.utils.extmath.weighted_mode`:

```sh
>>> from scipy import sparse
>>> import numpy as np
>>> from sklearn.utils.extmath import weighted_mode
>>> from scipy.stats import mode

>>> x = np.random.random((1000,))
>>> y = np.ones((1000,))
>>> %timeit weighted_mode(x,y)
30.6 ms ± 1.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
>>> %timeit mode(x)
25.1 ms ± 1.86 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

>>> x = np.random.random((100000,))
>>> y = np.ones((100000,))
>>> %timeit weighted_mode(x,y)
30.1 s ± 2.22 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
>>> %timeit mode(x)
15.5 s ± 90.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
